### PR TITLE
adding fix for git URL path join

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Ansible Techlab is built using the static page generator [Hugo](https://gohugo.i
 
 The page uses the [dot theme](https://github.com/themefisher/dot) which is included as a Git Submodule.
 
+After cloning the main repo, you need to initialize the submodule like this: 
+
+```bash
+git submodule update --init --recursive
+``` 
+
 ## Build using Docker
 
 Build the image:

--- a/config.toml
+++ b/config.toml
@@ -36,7 +36,7 @@ textColorDark = "#242738"
 whiteColor = "#ffffff"
 
 # public Git Repo - used for "improve this page" links
-gitRepoUrl = "https://github.com/puzzle/ansible-techlab/"
+gitRepoUrl = "https://github.com/puzzle/ansible-techlab"
 
 ############################## social links ##############################
 [[params.social]]

--- a/layouts/partials/lab.html
+++ b/layouts/partials/lab.html
@@ -21,7 +21,7 @@
           {{ if .Site.Params.GitRepoUrl }}
           <div class="float-right">
             <span class="ti-pencil"> </span>
-            <a href="{{ path.Join .Site.Params.GitRepoUrl "/edit/master/content" }}/{{ .File }}">
+            <a href="{{ .Site.Params.GitRepoUrl }}/edit/master/content/{{ .File }}">
               Improve this page
             </a>
           </div>


### PR DESCRIPTION
Adding fix for git URL path join as Hugo's path.Join function accidentally removed the double slash from the protocol