### PR TITLE
Remove tofu navigation and replace with arrow

### DIFF
--- a/content/about/_index.en.md
+++ b/content/about/_index.en.md
@@ -2,7 +2,7 @@
 title: "About"
 icon: "ti-info-alt"
 description: "About Ansible Techlab"
-type : "pages"
+type : "docs"
 weight: 10
 ---
 

--- a/content/agenda/_index.en.md
+++ b/content/agenda/_index.en.md
@@ -2,7 +2,7 @@
 title: "Slides"
 icon: "ti-blackboard"
 description: "Getting started with Ansible"
-type : "pages"
+type : "docs"
 weight: 1
 ---
 

--- a/content/labs/_index.en.md
+++ b/content/labs/_index.en.md
@@ -2,7 +2,7 @@
 title: "Labs"
 icon: "ti-panel"
 description: "Ansible Techlabs"
-type : "pages"
+type : "docs"
 weight: 2
 ---
 


### PR DESCRIPTION
Summary:
  * Moving dot theme to commit 78d860 which fixes
    the tofu problem in `assets/css/style.css` for
    element `.back-btn::before`
  * Changed type from `pages` to `docs` to restore
    the site navigation.

**before**
![image](https://user-images.githubusercontent.com/12977873/78801071-79a6ab80-79bc-11ea-9691-9fdcba4e7079.png)

**after**
![image](https://user-images.githubusercontent.com/12977873/78801093-81665000-79bc-11ea-941c-441a28901fa9.png)
