### PR TITLE
review of techlab

### DIFF
--- a/content/labs/04.0/_index.en.md
+++ b/content/labs/04.0/_index.en.md
@@ -34,14 +34,14 @@ Check what the options "immediate" and "permanent" of the firewalld module mean 
 
 ### TASK 4
 - Create a playbook `tempfolder.yml`
-- The playbook `tempfolder.yml` should create a temporary folder `/root/tempfolder` on all servers except those in the group `db`.
+- The playbook `tempfolder.yml` should create a temporary folder `/var/tempfolder` on all servers except those in the group `db`.
 
 {{% notice tip %}}
 Have a look at the user guide to know how to use more complex inventory patterns.
 See [Ansible Docs - User Guide ](https://docs.ansible.com/ansible/latest/user_guide/intro_patterns.html#common-patterns)
 {{% /notice %}}
 
-- The folder has to have the sticky bit set, so that only the owner of the content (or root) can delete the files.
+- The folder has to have the sticky bit set, so that only the owner (set owner/group to `ansible`) of the content (or root) can delete the files.
 - Run the playbook and then check if the sticky bit was set using an ad hoc command.
 
 ## Solutions
@@ -162,15 +162,17 @@ $ cat tempfolder.yml
   tasks:
     - name: create temp folder with sticky bit set
       file:
-        dest: /root/tempfolder
+        dest: /var/tempfolder
         mode: "01755"
+        owner: ansible
+        group: ansible
         state: directory
 
 $ ansible-playbook tempfolder.yml
 $ ansible web,controller -b -a "ls -lah /root/"
 ```
 {{% notice note %}}
-`ansible-doc file` doesn't provide any information about setting special permissions like sticky bit. Remember to use a leading 0 before the actual permissions.
+`ansible-doc file` doesn't provide any information about setting special permissions like sticky bit (`man chmod` will help you though). Remember to use a leading 0 before the actual permissions.
 {{% /notice %}}
 
 {{% /collapse %}}

--- a/content/labs/04.2/_index.en.md
+++ b/content/labs/04.2/_index.en.md
@@ -55,7 +55,7 @@ Create a playbook userplay.yml doing the following and running on node1 and node
 #### Bonus 2
 - On node2: If (and only if) the user is santos, disable login. This means set the shell to /usr/sbin/nologin and use a if/else statement in the template to do so.
 
-#### Bonus 3 
+#### Bonus 3
 - All on node2:
 - Set the default password on all servers to "`N0t_5o_s3cur3`"
 - Once the password was set, your playbook should not set it again. Not even when it got changed.
@@ -72,9 +72,9 @@ Be aware that it is NOT a good idea to set passwords in cleartext. We will learn
 Create a playbook `serverinfo.yml` that does the following:
 
 - Place on all nodes a file `/root/serverinfo.txt` with a line like follows for each and every server in the inventory:
-```  
+```
 <hostname>: OS: <operating system> IP: <IP address> Virtualization Role: <hardware type>
-``` 
+```
 
 - Replace `hostname`, `operating system`, `IP address` and `hardware type` with a reasonable fact.
 - Run your playbook and check on all servers by using an ansible ad hoc command if the content of the file `/root/serverinfo.txt` is as expected.
@@ -127,7 +127,7 @@ Rerun the playbook and check if the text has been changed accordingly:
 ```bash
 $ ansible-playbook motd.yml -l node1,node2
 $ ansible -i hosts all -a "cat /etc/motd"
-``` 
+```
 {{% /collapse %}}
 
 {{% collapse solution-3 "Solution 3" %}}
@@ -237,12 +237,12 @@ $ ssh jim@node2
 {{% collapse solution-4 "Solution 4" %}}
 Possible solution 1:
 ```bash
-$ cat serverinfo.txt.j2 
-{% for host in groups['nodes'] %}
+$ cat serverinfo.txt.j2
+{% for host in groups['all'] %}
 {{ hostvars[host].ansible_hostname }}: OS: {{ hostvars[host].ansible_os_family }} IP: {{ hostvars[host].ansible_default_ipv4.address }} Virtualization Role: {{ hostvars[host].ansible_virtualization_role }}
 {% endfor %}
 
-$ cat serverinfo.yml 
+$ cat serverinfo.yml
 ---
 - hosts: all
   become: true

--- a/content/labs/06.0/_index.en.md
+++ b/content/labs/06.0/_index.en.md
@@ -7,7 +7,7 @@ In this lab we are going to practice encryption in Ansible playbooks. It assumes
 
 ### Task 1
 
-- Create a simple playbook called `secretservice.yml` which creates a file `MI6` in the `/etc/` directory on node1 and node2. Use the `template` module and a template named `nsa.j2`. Don’t encrypt anything yet and use the inventory hosts from the earlier labs.
+- Create a simple playbook called `secretservice.yml` which creates a file `MI6` in the `/etc/` directory on node1 and node2. Use the `template` module and a template named `mi6.j2`. Don’t encrypt anything yet and use the inventory hosts from the earlier labs.
 - The content of the file `MI6` should be:
   ```
     username: jamesbond
@@ -22,12 +22,11 @@ In this lab we are going to practice encryption in Ansible playbooks. It assumes
     var_username: jamesbond
     var_password: miss_moneypenny
   ```
-- Rewrite the `nsa.j2` template to use the variables from the `secret_vars.yml` file. Nothing is encrypted yet.
+- Rewrite the `mi6.j2` template to use the variables from the `secret_vars.yml` file. Nothing is encrypted yet.
 - Rerun the playbook and remember nothing has been encrypted yet.
 
 ### Task 3
 
-- Create a file named `vaultpassword` containing the unencrypted string "goldfinger".
 - Encrypt the `secret_vars.yml` file by using `ansible-vault` with the password *goldfinger*.
 
 {{% notice tip %}}
@@ -44,6 +43,7 @@ Since the password is in cleartext in the file vaultpassword, you shoul never ev
 
 ### Task 4
 
+- Create a file named `vaultpassword` containing the unencrypted string "goldfinger".
 - Configure your environment to always use the `vaultpassword` file as the vault file.
 - Rerun the playbook without providing the password or the passwordfile at the commandline.
 
@@ -66,7 +66,7 @@ Look for an option to ansible-vault to give the name of the variable while encry
 - Change the encryption of the file: encrpyt it with another password provided at the commandline.
 
 {{% notice note %}}
- Don't do this by decrypting & reencrypting but rather by using the `rekey` option. 
+ Don't do this by decrypting & reencrypting but rather by using the `rekey` option.
  There's a trap hidden here. Doublecheck if everything worked as you expected.
 {{% /notice %}}
 
@@ -84,18 +84,18 @@ Take a look at [docs.ansible.com](https://docs.ansible.com)
 
 {{% collapse solution-1 "Solution 1" %}}
 ```bash
-$ cat nsa.j2 
+$ cat mi6.j2
 username: jamesbond
 password: miss_moneypenny
 
-$ cat secretservice.yml 
+$ cat secretservice.yml
 ---
 - hosts: node1, node2
   become: yes
   tasks:
     - name: put template
       template:
-        src: nsa.j2
+        src: mi6.j2
         dest: /etc/MI6
 
 $ ansible-playbook secretservice.yml
@@ -106,16 +106,16 @@ $ ansible-playbook secretservice.yml
 {{% collapse solution-2 "Solution 2" %}}
 
 ```bash
-$ cat secret_vars.yml 
+$ cat secret_vars.yml
 ---
 var_username: jamesbond
 var_password: miss_moneypenny
 
-$ cat nsa.j2 
+$ cat mi6.j2
 username: {{ var_username }}
 password: {{ var_password }}
 
-$ cat secretservice.yml 
+$ cat secretservice.yml
 ---
 - hosts: node1, node2
   become: yes
@@ -124,7 +124,7 @@ $ cat secretservice.yml
   tasks:
     - name: put template
       template:
-        src: nsa.j2
+        src: mi6.j2
         dest: /etc/MI6
 
 $ ansible-playbook secretservice.yml
@@ -133,7 +133,7 @@ $ ansible-playbook secretservice.yml
 
 {{% collapse solution-3 "Solution 3" %}}
 ```bash
-$ cat vaultpassword 
+$ cat vaultpassword
 goldfinger
 
 $ ansible-vault encrypt secret_vars.yml --vault-id vaultpassword
@@ -147,7 +147,7 @@ $ ansible-playbook secretservice.yml --vault-id vaultpassword
 Make sure you recieve the following output in your terminal:
 
 ```bash
-$ grep ^vault /home/ansible/techlab/ansible.cfg 
+$ grep ^vault /home/ansible/techlab/ansible.cfg
 vault_password_file = /home/ansible/techlab/vaultpassword
 
 $ ansible-playbook secretservice.yml
@@ -193,7 +193,7 @@ $ ansible-playbook secretservice.yml
 $ ansible node1,node2 -i inventory/hosts -b -a "rm /etc/MI6"
 ```
 
-{{% notice tip %}} 
+{{% notice tip %}}
 Note that the `command` module is the `default` module and therefore has not to be specified here.
 {{% /notice %}}
 

--- a/content/labs/07.0/_index.en.md
+++ b/content/labs/07.0/_index.en.md
@@ -35,16 +35,16 @@ You have to have a reasonable fresh version of ansible in order to get this work
 {{% collapse solution-1 "Solution 1" %}}
 ```bash
 $ ansible-galaxy search nginx
-$ ansible-galaxy install geerlingguy.nginx
-$ ansible controller -m archive -a "path=/home/ansible/techlab/roles/geerlingguy.nginx dest=/home/ansible/techlab/nginx.tar.gz format=bz2"
+$ ansible-galaxy install nginxinc.nginx
+$ ansible controller -m archive -a "path=/home/ansible/techlab/roles/nginxinc.nginx dest=/home/ansible/techlab/nginx.tar.gz"
 ```
 {{% /collapse %}}
 
 {{% collapse solution-2 "Solution 2" %}}
 ```bash
-$ ansible-galaxy remove geerlingguy.nginx
+$ ansible-galaxy remove nginxinc.nginx
 
-$ cat roles/requirements.yml 
+$ cat roles/requirements.yml
 ---
 - src: nginx.tar.gz
   name: mynginx
@@ -91,4 +91,5 @@ $ cp /usr/share/doc/rhel-system-roles-1.0/selinux/example-selinux-playbook.yml s
 
 $ ansible-playbook selinux.yml
 ```
+Before you can use `rhel-system-roles` you need to add them to the `roles_path` variable in your `ansible.cfg`
 {{% /collapse %}}


### PR DESCRIPTION
I did the Techlab today and found some stuff I would change, here's why (I did not comment on why one would like to remove trailing whitespace):

- sticky bit Task my be more interesting in a non home folder, where we can play with permissions and ownership
- added where one could find some information about sticky bit in a exam env
- changed group to `all` since not only `hosts` are required by task
- I wouldn't mix secret services from different Countries, this does not end well most times
- we do not need a `vaultpassword` file if we enter the password with `--ask-pas...` but we need it in the next task
- when installing galaxy-roles I would recommend to check if there is an official one rather than to default to geerlingguy
- a archive is either a `gz` or a `bz2` compressed tarball but not both at once
- added info how to debug, if role can't be found

Hope this is usefull, keep up the good work
